### PR TITLE
HOCS-2097 Autoscale Replicas

### DIFF
--- a/kd/autoscale.yaml
+++ b/kd/autoscale.yaml
@@ -6,7 +6,7 @@ metadata:
   name: hocs-casework
 spec:
   maxReplicas: 2
-  minReplicas: 1
+  minReplicas: {{.REPLICAS}}
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment


### PR DESCRIPTION
The minimum instances for a given target environment is set in the deploy script. Using this value to set the default number of minimum instances for the service.