### PR TITLE
HOCS-2640: refactor deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
+set -euo pipefail
 
 export KUBE_NAMESPACE=${ENVIRONMENT}
 export KUBE_SERVER=${KUBE_SERVER}
-
-if [[ -z ${VERSION} ]] ; then
-    export VERSION=${IMAGE_VERSION}
-fi
+export KUBE_TOKEN=${KUBE_TOKEN}
+export VERSION=${VERSION}
 
 if [[ ${KUBE_NAMESPACE} == *prod ]]
 then
@@ -14,42 +13,6 @@ then
 else
     export MIN_REPLICAS="1"
     export MAX_REPLICAS="2"
-fi
-
-if [[ ${KUBE_NAMESPACE} == "cs-prod" ]] ; then
-    echo "deploy ${VERSION} to PROD namespace, using HOCS_CASEWORK_PROD_CS drone secret"
-    export KUBE_TOKEN=${HOCS_CASEWORK_PROD_CS}
-elif [[ ${KUBE_NAMESPACE} == "wcs-prod" ]] ; then
-    echo "deploy ${VERSION} to PROD namespace, using HOCS_CASEWORK_PROD_WCS drone secret"
-    export KUBE_TOKEN=${HOCS_CASEWORK_PROD_WCS}
-elif [[ ${KUBE_NAMESPACE} == "cs-qa" ]] ; then
-    echo "deploy ${VERSION} to QA namespace, using HOCS_CASEWORK_QA_CS drone secret"
-    export KUBE_TOKEN=${HOCS_CASEWORK_QA_CS}
-elif [[ ${KUBE_NAMESPACE} == "wcs-qa" ]] ; then
-    echo "deploy ${VERSION} to QA namespace, using HOCS_CASEWORK_QA_WCS drone secret"
-    export KUBE_TOKEN=${HOCS_CASEWORK_QA_WCS}
-elif [[ ${KUBE_NAMESPACE} == "cs-demo" ]] ; then
-    echo "deploy ${VERSION} to DEMO namespace, using HOCS_CASEWORK_DEMO_CS drone secret"
-    export KUBE_TOKEN=${HOCS_CASEWORK_DEMO_CS}
-elif [[ ${KUBE_NAMESPACE} == "wcs-demo" ]] ; then
-    echo "deploy ${VERSION} to DEMO namespace, using HOCS_CASEWORK_DEMO_WCS drone secret"
-    export KUBE_TOKEN=${HOCS_CASEWORK_DEMO_WCS}
-elif [[ ${KUBE_NAMESPACE} == "cs-dev" ]] ; then
-    echo "deploy ${VERSION} to DEV namespace, using HOCS_CASEWORK_DEV_CS drone secret"
-    export KUBE_TOKEN=${HOCS_CASEWORK_DEV_CS}
-elif [[ ${KUBE_NAMESPACE} == "wcs-dev" ]] ; then
-    echo "deploy ${VERSION} to DEV namespace, using HOCS_CASEWORK_DEV_WCS drone secret"
-    export KUBE_TOKEN=${HOCS_CASEWORK_DEV_WCS}
-elif [[ ${KUBE_NAMESPACE} == "hocs-qax" ]] ; then
-    echo "deploy ${VERSION} to QAX namespace, using HOCS_CASEWORK_QAX drone secret"
-    export KUBE_TOKEN=${HOCS_CASEWORK_QAX}
-else
-    echo "Unable to find environment: ${ENVIRONMENT}"
-fi
-
-if [[ -z ${KUBE_TOKEN} ]] ; then
-    echo "Failed to find a value for KUBE_TOKEN - exiting"
-    exit -1
 fi
 
 cd kd


### PR DESCRIPTION
Currently we have a if/else tower that handles the setting of the
`KUBE_TOKEN` environment variable. As we are now passing this
in directly this is no longer needed. Alongside this, we now set the
pipeline to fail if it returns a none 0 status code from a command.
Improve to only have to use the VERSION parameter.